### PR TITLE
Fix length(null) condition when custom_origin_config is missed

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -91,7 +91,7 @@ resource "aws_cloudfront_distribution" "this" {
       }
 
       dynamic "custom_origin_config" {
-        for_each = length(lookup(origin.value, "custom_origin_config", "")) == 0 ? [] : [lookup(origin.value, "custom_origin_config", "")]
+        for_each = lookup(origin.value, "custom_origin_config", null) == null ? [] : [lookup(origin.value, "custom_origin_config", {})]
 
         content {
           http_port                = custom_origin_config.value.http_port


### PR DESCRIPTION
We get
```
╷
│ Error: Invalid function argument
│
│   on .terraform/modules/distribution/main.tf line 94, in resource "aws_cloudfront_distribution" "this":
│   94:         for_each = length(lookup(origin.value, "custom_origin_config", "")) == 0 ? [] : [lookup(origin.value, "custom_origin_config", "")]
│     ├────────────────
│     │ origin.value is object with 4 attributes
│
│ Invalid value for "value" parameter: argument must not be null.
```
when `custom_origin_config` is missed in a `origin.foo` input. This is maybe because the `lookup()` returns null instead of an empty string and `length()` on this null value causes the error